### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ include/
 *.class
 *.orig
 *~
+.pytest_cache
 
 flycheck-*
 flycheck_*
@@ -24,6 +25,7 @@ doc/*/_build
 build/
 dist/
 *.egg-info
+*.eggs
 issue/
 env/
 3rdparty/
@@ -33,3 +35,5 @@ env/
 .ropeproject
 .idea
 .env
+AUTHORS
+ChangeLog

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 sudo: false
 python:
-- '2.7'
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install:
-- pip install -r test_requirements.txt
-- pip install -e .
+- pip install -e ".[testing]"
 script:
-- py.test
+- pytest
 deploy:
   provider: pypi
   user: vmalloc

--- a/dessert/__version__.py
+++ b/dessert/__version__.py
@@ -1,1 +1,3 @@
-__version__ = "1.3.4"
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('dessert').version

--- a/dessert/pathlib.py
+++ b/dessert/pathlib.py
@@ -1,0 +1,48 @@
+# pylint: disable=unused-import,import-error
+import fnmatch
+import os
+import sys
+from os.path import sep
+from posixpath import sep as posix_sep
+
+
+if sys.version_info[:2] >= (3, 6):
+    from pathlib import Path, PurePath
+else:
+    from pathlib2 import Path, PurePath
+
+
+def fnmatch_ex(pattern, path):
+    """FNMatcher port from py.path.common which works with PurePath() instances.
+
+    The difference between this algorithm and PurePath.match() is that the latter matches "**" glob expressions
+    for each part of the path, while this algorithm uses the whole path instead.
+
+    For example:
+        "tests/foo/bar/doc/test_foo.py" matches pattern "tests/**/doc/test*.py" with this algorithm, but not with
+        PurePath.match().
+
+    This algorithm was ported to keep backward-compatibility with existing settings which assume paths match according
+    this logic.
+
+    References:
+    * https://bugs.python.org/issue29249
+    * https://bugs.python.org/issue34731
+    """
+
+    path = PurePath(path)
+    iswin32 = sys.platform.startswith("win")
+
+    if iswin32 and sep not in pattern and posix_sep in pattern:
+        # Running on Windows, the pattern has no Windows path separators,
+        # and the pattern has one or more Posix path separators. Replace
+        # the Posix path separators with the Windows path separator.
+        pattern = pattern.replace(posix_sep, sep)
+
+    if sep not in pattern:
+        name = path.name
+    else:
+        name = str(path)
+        if path.is_absolute() and not os.path.isabs(pattern):
+            pattern = "*{}{}".format(os.sep, pattern)
+    return fnmatch.fnmatch(name, pattern)

--- a/dessert/saferepr.py
+++ b/dessert/saferepr.py
@@ -1,0 +1,67 @@
+import pprint
+import reprlib
+
+
+def _format_repr_exception(exc, obj):
+    exc_name = type(exc).__name__
+    try:
+        exc_info = str(exc)
+    except Exception:
+        exc_info = "unknown"
+    return '<[{}("{}") raised in repr()] {} object at 0x{:x}>'.format(
+        exc_name, exc_info, obj.__class__.__name__, id(obj)
+    )
+
+
+def _ellipsize(s, maxsize):
+    if len(s) > maxsize:
+        i = max(0, (maxsize - 3) // 2)
+        j = max(0, maxsize - 3 - i)
+        return s[:i] + "..." + s[len(s) - j :]
+    return s
+
+
+class SafeRepr(reprlib.Repr):
+    """subclass of repr.Repr that limits the resulting size of repr()
+    and includes information on exceptions raised during the call.
+    """
+
+    def __init__(self, maxsize):
+        super().__init__()
+        self.maxstring = maxsize
+        self.maxsize = maxsize
+
+    def repr(self, x):
+        try:
+            s = super().repr(x)
+        except Exception as exc:
+            s = _format_repr_exception(exc, x)
+        return _ellipsize(s, self.maxsize)
+
+    def repr_instance(self, x, level):
+        try:
+            s = repr(x)
+        except Exception as exc:
+            s = _format_repr_exception(exc, x)
+        return _ellipsize(s, self.maxsize)
+
+
+def safeformat(obj):
+    """return a pretty printed string for the given object.
+    Failing __repr__ functions of user instances will be represented
+    with a short exception info.
+    """
+    try:
+        return pprint.pformat(obj)
+    except Exception as exc:
+        return _format_repr_exception(exc, obj)
+
+
+def saferepr(obj, maxsize=240):
+    """return a size-limited safe repr-string for the given object.
+    Failing __repr__ functions of user instances will be represented
+    with a short exception info and 'saferepr' generally takes
+    care to never raise exceptions itself.  This function is a wrapper
+    around the Repr/reprlib functionality of the standard 2.6 lib.
+    """
+    return SafeRepr(maxsize).repr(obj)

--- a/dessert/util.py
+++ b/dessert/util.py
@@ -1,33 +1,32 @@
 """Utilities for assertion debugging"""
+import attr
 import pprint
 import logging
+from collections.abc import Sequence
+from typing import Callable
+from typing import List
+from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
-import py
 from .conf import conf
-try:
-    from collections import Sequence
-except ImportError:
-    Sequence = list
+from .saferepr import saferepr
 
-BuiltinAssertionError = py.builtin.builtins.AssertionError
-u = py.builtin._totext
+if getattr(attr, "__version_info__", ()) >= (19, 2):
+    ATTRS_EQ_FIELD = "eq"
+else:
+    ATTRS_EQ_FIELD = "cmp"
+
 
 # The _reprcompare attribute on the util module is used by the new assertion
 # interpretation code and assertion rewriter to detect this plugin was
 # loaded and in turn call the hooks defined here as part of the
 # DebugInterpreter.
-_reprcompare = None
+_reprcompare = None  # type: Optional[Callable[[str, object, object], Optional[str]]]
 
-
-# the re-encoding is needed for python2 repr
-# with non-ascii characters (see issue 877 and 1379)
-def ecu(s):
-    try:
-        return u(s, 'utf-8', 'replace')
-    except TypeError:
-        return s
+# Works similarly as _reprcompare attribute. Is populated with the hook call
+# when pytest_runtest_setup is called.
+_assertion_pass = None  # type: Optional[Callable[[int, str, str], None]]
 
 
 def format_explanation(explanation, original_msg=None):
@@ -42,10 +41,10 @@ def format_explanation(explanation, original_msg=None):
     """
     if not conf.is_message_introspection_enabled() and original_msg:
         return original_msg
-    explanation = ecu(explanation)
+    explanation = explanation
     lines = _split_explanation(explanation)
     result = _format_lines(lines)
-    return u('\n').join(result)
+    return "\n".join(result)
 
 
 def _split_explanation(explanation):
@@ -55,13 +54,13 @@ def _split_explanation(explanation):
     Any other newlines will be escaped and appear in the line as the
     literal '\n' characters.
     """
-    raw_lines = (explanation or u('')).split('\n')
+    raw_lines = (explanation or "").split("\n")
     lines = [raw_lines[0]]
-    for l in raw_lines[1:]:
-        if l and l[0] in ['{', '}', '~', '>']:
-            lines.append(l)
+    for values in raw_lines[1:]:
+        if values and values[0] in ["{", "}", "~", ">"]:
+            lines.append(values)
         else:
-            lines[-1] += '\\n' + l
+            lines[-1] += "\\n" + values
     return lines
 
 
@@ -78,60 +77,71 @@ def _format_lines(lines):
     stack = [0]
     stackcnt = [0]
     for line in lines[1:]:
-        if line.startswith('{'):
+        if line.startswith("{"):
             if stackcnt[-1]:
-                s = u('and   ')
+                s = "and   "
             else:
-                s = u('where ')
+                s = "where "
             stack.append(len(result))
             stackcnt[-1] += 1
             stackcnt.append(0)
-            result.append(u(' +') + u('  ')*(len(stack)-1) + s + line[1:])
-        elif line.startswith('}'):
+            result.append(" +" + "  " * (len(stack) - 1) + s + line[1:])
+        elif line.startswith("}"):
             stack.pop()
             stackcnt.pop()
             result[stack[-1]] += line[1:]
         else:
-            assert line[0] in ['~', '>']
+            assert line[0] in ["~", ">"]
             stack[-1] += 1
-            indent = len(stack) if line.startswith('~') else len(stack) - 1
-            result.append(u('  ')*indent + line[1:])
+            indent = len(stack) if line.startswith("~") else len(stack) - 1
+            result.append("  " * indent + line[1:])
     assert len(stack) == 1
     return result
 
+def issequence(x):
+    return isinstance(x, Sequence) and not isinstance(x, str)
 
-# Provide basestring in python3
-try:
-    basestring = basestring
-except NameError:
-    basestring = str
+
+def istext(x):
+    return isinstance(x, str)
+
+
+def isdict(x):
+    return isinstance(x, dict)
+
+
+def isset(x):
+    return isinstance(x, (set, frozenset))
+
+
+def isdatacls(obj):
+    return getattr(obj, "__dataclass_fields__", None) is not None
+
+
+def isattrs(obj):
+    return getattr(obj, "__attrs_attrs__", None) is not None
+
+
+def isiterable(obj):
+    try:
+        iter(obj)
+        return not istext(obj)
+    except TypeError:
+        return False
 
 
 def assertrepr_compare(config, op, left, right):
     """Return specialised explanations for some operators/operands"""
-    width = 80 - 15 - len(op) - 2  # 15 chars indentation, 1 space around op
-    left_repr = py.io.saferepr(left, maxsize=int(width//2))
-    right_repr = py.io.saferepr(right, maxsize=width-len(left_repr))
+    maxsize = (80 - 15 - len(op) - 2) // 2  # 15 chars indentation, 1 space around op
+    left_repr = saferepr(left, maxsize=maxsize)
+    right_repr = saferepr(right, maxsize=maxsize)
 
-    summary = u('%s %s %s') % (ecu(left_repr), op, ecu(right_repr))
+    summary = "{} {} {}".format(left_repr, op, right_repr)
 
-    issequence = lambda x: (isinstance(x, (list, tuple, Sequence)) and
-                            not isinstance(x, basestring))
-    istext = lambda x: isinstance(x, basestring)
-    isdict = lambda x: isinstance(x, dict)
-    isset = lambda x: isinstance(x, (set, frozenset))
-
-    def isiterable(obj):
-        try:
-            iter(obj)
-            return not istext(obj)
-        except TypeError:
-            return False
-
-    verbose = config.getoption('verbose')
+    verbose = config.getoption("verbose")
     explanation = None
     try:
-        if op == '==':
+        if op == "==":
             if istext(left) and istext(right):
                 explanation = _diff_text(left, right, verbose)
             else:
@@ -141,13 +151,18 @@ def assertrepr_compare(config, op, left, right):
                     explanation = _compare_eq_set(left, right, verbose)
                 elif isdict(left) and isdict(right):
                     explanation = _compare_eq_dict(left, right, verbose)
+                elif type(left) == type(right) and (isdatacls(left) or isattrs(left)):  # pylint: disable=unidiomatic-typecheck
+                    type_fn = (isdatacls, isattrs)
+                    explanation = _compare_eq_cls(left, right, verbose, type_fn)
+                elif verbose > 0:
+                    explanation = _compare_eq_verbose(left, right)
                 if isiterable(left) and isiterable(right):
                     expl = _compare_eq_iterable(left, right, verbose)
                     if explanation is not None:
                         explanation.extend(expl)
                     else:
                         explanation = expl
-        elif op == 'not in':
+        elif op == "not in":
             if istext(left) and istext(right):
                 explanation = _notin_text(left, right, verbose)
     except Exception:
@@ -160,8 +175,8 @@ def assertrepr_compare(config, op, left, right):
     return [summary] + explanation
 
 
-def _diff_text(left, right, verbose=False):
-    """Return the explanation for the diff between text or bytes
+def _diff_text(left, right, verbose=0):
+    """Return the explanation for the diff between text or bytes.
 
     Unless --verbose is used this will skip leading and trailing
     characters which are identical to keep the diff minimal.
@@ -169,20 +184,34 @@ def _diff_text(left, right, verbose=False):
     If the input are bytes they will be safely converted to text.
     """
     from difflib import ndiff
-    explanation = []
-    if isinstance(left, py.builtin.bytes):
-        left = u(repr(left)[1:-1]).replace(r'\n', '\n')
-    if isinstance(right, py.builtin.bytes):
-        right = u(repr(right)[1:-1]).replace(r'\n', '\n')
-    if not verbose:
+
+    explanation = []  # type: List[str]
+
+    def escape_for_readable_diff(binary_text):
+        """
+        Ensures that the internal string is always valid unicode, converting any bytes safely to valid unicode.
+        This is done using repr() which then needs post-processing to fix the encompassing quotes and un-escape
+        newlines and carriage returns (#429).
+        """
+        r = str(repr(binary_text)[1:-1])
+        r = r.replace(r"\n", "\n")
+        r = r.replace(r"\r", "\r")
+        return r
+
+    if isinstance(left, bytes):
+        left = escape_for_readable_diff(left)
+    if isinstance(right, bytes):
+        right = escape_for_readable_diff(right)
+    if verbose < 1:
         i = 0  # just in case left or right has zero length
         for i in range(min(len(left), len(right))):
             if left[i] != right[i]:
                 break
         if i > 42:
-            i -= 10                 # Provide some context
-            explanation = [u('Skipping %s identical leading '
-                             'characters in diff, use -v to show') % i]
+            i -= 10  # Provide some context
+            explanation = [
+                "Skipping %s identical leading characters in diff, use -v to show" % i
+            ]
             left = left[i:]
             right = right[i:]
         if len(left) == len(right):
@@ -190,114 +219,223 @@ def _diff_text(left, right, verbose=False):
                 if left[-i] != right[-i]:
                     break
             if i > 42:
-                i -= 10     # Provide some context
-                explanation += [u('Skipping %s identical trailing '
-                                  'characters in diff, use -v to show') % i]
+                i -= 10  # Provide some context
+                explanation += [
+                    "Skipping {} identical trailing "
+                    "characters in diff, use -v to show".format(i)
+                ]
                 left = left[:-i]
                 right = right[:-i]
     keepends = True
-    explanation += [line.strip('\n')
-                    for line in ndiff(left.splitlines(keepends),
-                                      right.splitlines(keepends))]
+    if left.isspace() or right.isspace():
+        left = repr(str(left))
+        right = repr(str(right))
+        explanation += ["Strings contain only whitespace, escaping them using repr()"]
+    explanation += [
+        line.strip("\n")
+        for line in ndiff(left.splitlines(keepends), right.splitlines(keepends))
+    ]
     return explanation
 
 
-def _compare_eq_iterable(left, right, verbose=False):
+def _compare_eq_verbose(left, right):
+    keepends = True
+    left_lines = repr(left).splitlines(keepends)
+    right_lines = repr(right).splitlines(keepends)
+
+    explanation = []  # type: List[str]
+    explanation += ["-" + line for line in left_lines]
+    explanation += ["+" + line for line in right_lines]
+
+    return explanation
+
+
+def _compare_eq_iterable(left, right, verbose=0):
     if not verbose:
-        return [u('Use -v to get the full diff')]
+        return ["Use -v to get the full diff"]
     # dynamic import to speedup pytest
     import difflib
 
-    try:
-        left_formatting = pprint.pformat(left).splitlines()
-        right_formatting = pprint.pformat(right).splitlines()
-        explanation = [u('Full diff:')]
-    except Exception:
-        # hack: PrettyPrinter.pformat() in python 2 fails when formatting items that can't be sorted(), ie, calling
-        # sorted() on a list would raise. See issue #718.
-        # As a workaround, the full diff is generated by using the repr() string of each item of each container.
-        left_formatting = sorted(repr(x) for x in left)
-        right_formatting = sorted(repr(x) for x in right)
-        explanation = [u('Full diff (fallback to calling repr on each item):')]
-    explanation.extend(line.strip() for line in difflib.ndiff(left_formatting, right_formatting))
+    left_formatting = pprint.pformat(left).splitlines()
+    right_formatting = pprint.pformat(right).splitlines()
+    explanation = ["Full diff:"]
+    explanation.extend(
+        line.strip() for line in difflib.ndiff(left_formatting, right_formatting)
+    )
     return explanation
 
 
-def _compare_eq_sequence(left, right, verbose=False):
-    explanation = []
-    for i in range(min(len(left), len(right))):
+def _compare_eq_iterable(left, right, verbose=0):
+    if not verbose:
+        return ["Use -v to get the full diff"]
+    # dynamic import to speedup pytest
+    import difflib
+
+    left_formatting = pprint.pformat(left).splitlines()
+    right_formatting = pprint.pformat(right).splitlines()
+    explanation = ["Full diff:"]
+    explanation.extend(
+        line.strip() for line in difflib.ndiff(left_formatting, right_formatting)
+    )
+    return explanation
+
+
+def _compare_eq_sequence(left, right, verbose=0):
+    comparing_bytes = isinstance(left, bytes) and isinstance(right, bytes)
+    explanation = []  # type: List[str]
+    len_left = len(left)
+    len_right = len(right)
+    for i in range(min(len_left, len_right)):
         if left[i] != right[i]:
-            explanation += [u('At index %s diff: %r != %r')
-                            % (i, left[i], right[i])]
+            if comparing_bytes:
+                # when comparing bytes, we want to see their ascii representation
+                # instead of their numeric values (#5260)
+                # using a slice gives us the ascii representation:
+                # >>> s = b'foo'
+                # >>> s[0]
+                # 102
+                # >>> s[0:1]
+                # b'f'
+                left_value = left[i : i + 1]
+                right_value = right[i : i + 1]
+            else:
+                left_value = left[i]
+                right_value = right[i]
+
+            explanation += [
+                "At index {} diff: {!r} != {!r}".format(i, left_value, right_value)
+            ]
             break
-    if len(left) > len(right):
-        explanation += [u('Left contains more items, first extra item: %s')
-                        % py.io.saferepr(left[len(right)],)]
-    elif len(left) < len(right):
-        explanation += [
-            u('Right contains more items, first extra item: %s') %
-            py.io.saferepr(right[len(left)],)]
+
+    if comparing_bytes:
+        # when comparing bytes, it doesn't help to show the "sides contain one or more items"
+        # longer explanation, so skip it
+        return explanation
+
+    len_diff = len_left - len_right
+    if len_diff:
+        if len_diff > 0:
+            dir_with_more = "Left"
+            extra = saferepr(left[len_right])
+        else:
+            len_diff = 0 - len_diff
+            dir_with_more = "Right"
+            extra = saferepr(right[len_left])
+
+        if len_diff == 1:
+            explanation += [
+                "{} contains one more item: {}".format(dir_with_more, extra)
+            ]
+        else:
+            explanation += [
+                "%s contains %d more items, first extra item: %s"
+                % (dir_with_more, len_diff, extra)
+            ]
     return explanation
 
 
-def _compare_eq_set(left, right, verbose=False):
+def _compare_eq_set(left, right, verbose=0):
     explanation = []
     diff_left = left - right
     diff_right = right - left
     if diff_left:
-        explanation.append(u('Extra items in the left set:'))
+        explanation.append("Extra items in the left set:")
         for item in diff_left:
-            explanation.append(py.io.saferepr(item))
+            explanation.append(saferepr(item))
     if diff_right:
-        explanation.append(u('Extra items in the right set:'))
+        explanation.append("Extra items in the right set:")
         for item in diff_right:
-            explanation.append(py.io.saferepr(item))
+            explanation.append(saferepr(item))
     return explanation
 
 
 def _compare_eq_dict(left, right, verbose=False):
-    explanation = []
-    common = set(left).intersection(set(right))
-    same = dict((k, left[k]) for k in common if left[k] == right[k])
-    if same and not verbose:
-        explanation += [u('Omitting %s identical items, use -v to show') %
-                        len(same)]
+    explanation = []  # type: List[str]
+    set_left = set(left)
+    set_right = set(right)
+    common = set_left.intersection(set_right)
+    same = {k: left[k] for k in common if left[k] == right[k]}
+    if same and verbose < 2:
+        explanation += ["Omitting %s identical items, use -vv to show" % len(same)]
     elif same:
-        explanation += [u('Common items:')]
+        explanation += ["Common items:"]
         explanation += pprint.pformat(same).splitlines()
-    diff = set(k for k in common if left[k] != right[k])
+    diff = {k for k in common if left[k] != right[k]}
     if diff:
-        explanation += [u('Differing items:')]
+        explanation += ["Differing items:"]
         for k in diff:
-            explanation += [py.io.saferepr({k: left[k]}) + ' != ' +
-                            py.io.saferepr({k: right[k]})]
-    extra_left = set(left) - set(right)
-    if extra_left:
-        explanation.append(u('Left contains more items:'))
-        explanation.extend(pprint.pformat(
-            dict((k, left[k]) for k in extra_left)).splitlines())
-    extra_right = set(right) - set(left)
-    if extra_right:
-        explanation.append(u('Right contains more items:'))
-        explanation.extend(pprint.pformat(
-            dict((k, right[k]) for k in extra_right)).splitlines())
+            explanation += [saferepr({k: left[k]}) + " != " + saferepr({k: right[k]})]
+    extra_left = set_left - set_right
+    len_extra_left = len(extra_left)
+    if len_extra_left:
+        explanation.append(
+            "Left contains %d more item%s:"
+            % (len_extra_left, "" if len_extra_left == 1 else "s")
+        )
+        explanation.extend(
+            pprint.pformat({k: left[k] for k in extra_left}).splitlines()
+        )
+    extra_right = set_right - set_left
+    len_extra_right = len(extra_right)
+    if len_extra_right:
+        explanation.append(
+            "Right contains %d more item%s:"
+            % (len_extra_right, "" if len_extra_right == 1 else "s")
+        )
+        explanation.extend(
+            pprint.pformat({k: right[k] for k in extra_right}).splitlines()
+        )
     return explanation
 
 
-def _notin_text(term, text, verbose=False):
+def _compare_eq_cls(left, right, verbose, type_fns):
+    isdatacls, isattrs = type_fns
+    if isdatacls(left):
+        all_fields = left.__dataclass_fields__
+        fields_to_check = [field for field, info in all_fields.items() if info.compare]
+    elif isattrs(left):
+        all_fields = left.__attrs_attrs__
+        fields_to_check = [
+            field.name for field in all_fields if getattr(field, ATTRS_EQ_FIELD)
+        ]
+
+    same = []
+    diff = []
+    for field in fields_to_check:
+        if getattr(left, field) == getattr(right, field):
+            same.append(field)
+        else:
+            diff.append(field)
+
+    explanation = []
+    if same and verbose < 2:
+        explanation.append("Omitting %s identical items, use -vv to show" % len(same))
+    elif same:
+        explanation += ["Matching attributes:"]
+        explanation += pprint.pformat(same).splitlines()
+    if diff:
+        explanation += ["Differing attributes:"]
+        for field in diff:
+            explanation += [
+                ("%s: %r != %r") % (field, getattr(left, field), getattr(right, field))
+            ]
+    return explanation
+
+
+def _notin_text(term, text, verbose=0):
     index = text.find(term)
     head = text[:index]
-    tail = text[index+len(term):]
+    tail = text[index + len(term) :]
     correct_text = head + tail
     diff = _diff_text(correct_text, text, verbose)
-    newdiff = [u('%s is contained here:') % py.io.saferepr(term, maxsize=42)]
+    newdiff = ["%s is contained here:" % saferepr(term, maxsize=42)]
     for line in diff:
-        if line.startswith(u('Skipping')):
+        if line.startswith("Skipping"):
             continue
-        if line.startswith(u('- ')):
+        if line.startswith("- "):
             continue
-        if line.startswith(u('+ ')):
-            newdiff.append(u('  ') + line[2:])
+        if line.startswith("+ "):
+            newdiff.append("  " + line[2:])
         else:
             newdiff.append(line)
     return newdiff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+munch
+py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[metadata]
+name = dessert
+classifiers =
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+summary = Assertion introspection via AST rewriting
+description-file =
+    README.md
+description-content-type = text/markdown
+license = MIT
+author = Rotem Yaari
+author_email = vmalloc@gmail.com
+url = https://github.com/vmalloc/dessert
+
+[extras]
+testing =
+    pytest
+    emport>=1.1.1
+
+[tool:pytest]
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,10 @@
-import os
-import sys
-from setuptools import setup, find_packages
+#!/usr/bin/env python
+from setuptools import setup
 
-with open(os.path.join(os.path.dirname(__file__), "dessert", "__version__.py")) as version_file:
-    exec(version_file.read()) # pylint: disable=W0122
 
-_INSTALL_REQUIRES = [
-    "py",
-    "munch",
-]
-
-setup(name="dessert",
-      classifiers = [
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.3",
-          "Programming Language :: Python :: 3.4",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          ],
-      description="Assertion introspection via AST rewriting",
-      license="MIT",
-      author="Rotem Yaari",
-      author_email="vmalloc@gmail.com",
-      version=__version__, # pylint: disable=E0602
-      packages=find_packages(exclude=["tests"]),
-
-      url="https://github.com/vmalloc/dessert",
-
-      install_requires=_INSTALL_REQUIRES,
-      scripts=[],
-      namespace_packages=[]
-      )
+setup(
+    setup_requires=['pbr>=3.0', 'setuptools>=17.1'],
+    pbr=True,
+    python_requires=">=3.5.*",
+    long_description_content_type='text/markdown; charset=UTF-8',
+)

--- a/tests/test_dessert.py
+++ b/tests/test_dessert.py
@@ -55,6 +55,7 @@ def func():
 
 @pytest.fixture(scope='session', autouse=True)
 def mark_dessert():
+    # pylint: disable=protected-access
     assert not dessert.rewrite._MARK_ASSERTION_INTROSPECTION
     dessert.rewrite._MARK_ASSERTION_INTROSPECTION = True
 
@@ -65,7 +66,7 @@ def module(request, source_filename):
             module = emport.import_file(source_filename)
 
     @request.addfinalizer
-    def drop_from_sys_modules():
+    def drop_from_sys_modules():  # pylint: disable=unused-variable
         sys.modules.pop(module.__name__)
 
     return module
@@ -133,7 +134,7 @@ def source_filename(request, source):
     path = mkdtemp()
 
     @request.addfinalizer
-    def delete():
+    def delete():  # pylint: disable=unused-variable
         shutil.rmtree(path)
 
     filename = os.path.join(path, "sourcefile.py")

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py35,py36,py37,py38
 
 [testenv]
-commands = py.test
-deps = -rtest_requirements.txt
+commands = pytest
+extras =
+    testing
 changedir = {toxinidir}
-
-[testenv:py26]
-deps = 
-     -rtest_requirements.txt
-     importlib


### PR DESCRIPTION
This PR contains 2 commits:

1. Drop support for python version < 3.5 and switch to PBR
2. Use importlib instead of imp, because the latest is deprecated

I dropped support for old python versions because the new importlib is not compatible with them and imp is deprecated with the new versions.