### PR TITLE
Add python 3.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 - '3.6'
 - '3.7'
 - '3.8'
+- '3.9'
+- '3.10'
 install:
 - pip install -e ".[testing]"
 script:

--- a/dessert/rewrite.py
+++ b/dessert/rewrite.py
@@ -543,12 +543,6 @@ class AssertionRewriter(ast.NodeVisitor):
         if not mod.body:
             # Nothing to do.
             return
-        # Insert some special imports at the top of the module but after any
-        # docstrings and __future__ imports.
-        aliases = [
-            ast.alias("builtins", "@py_builtins"),
-            ast.alias("dessert.rewrite", "@dessert_ar"),
-        ]
         doc = getattr(mod, "docstring", None)
         expect_docstring = doc is None
         if doc is not None and self.is_rewrite_disabled(doc):
@@ -575,6 +569,18 @@ class AssertionRewriter(ast.NodeVisitor):
             pos += 1
         else:
             lineno = item.lineno
+        # Insert some special imports at the top of the module but after any
+        # docstrings and __future__ imports.
+        if sys.version_info < (3, 10):
+            aliases = [
+                ast.alias("builtins", "@py_builtins"),
+                ast.alias("dessert.rewrite", "@dessert_ar"),
+            ]
+        else:
+            aliases = [
+                ast.alias("builtins", "@py_builtins", lineno=lineno, col_offset=0),
+                ast.alias("dessert.rewrite", "@dessert_ar", lineno=lineno, col_offset=0),
+            ]
         imports = [
             ast.Import([alias], lineno=lineno, col_offset=0) for alias in aliases
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 summary = Assertion introspection via AST rewriting
 description-file =
     README.md

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py35,py36,py37,py38,py39,py310
 
 [testenv]
 commands = pytest


### PR DESCRIPTION
Fix `ast.alias` call in Python 3.10+

```
Traceback (most recent call last):
  File "/tmp/app/dessert/rewrite.py", line 144, in exec_module
    source_stat, co = _rewrite_test(fn, self.config)
  File "/tmp/app/dessert/rewrite.py", line 243, in _rewrite_test
    co = compile(tree, fn, "exec", dont_inherit=True)
TypeError: required field "lineno" missing from alias
```

