### PR TITLE
Only remove the added hook

### DIFF
--- a/dessert/__init__.py
+++ b/dessert/__init__.py
@@ -8,12 +8,11 @@ from .rewrite import AssertionRewritingHook
 @contextmanager
 def rewrite_assertions_context():
     hook = AssertionRewritingHook()
-    prev_meta_path = sys.meta_path[:]
     sys.meta_path.insert(0, hook)
     try:
         yield
     finally:
-        sys.meta_path[:] = prev_meta_path
+        sys.meta_path.remove(hook)
 
 
 def disable_message_introspection():


### PR DESCRIPTION
`sys.meta_path` could change inside the context, removing only the added hook (`AssertionRewritingHook`) is preferable and avoid causing undesirable side effects.