### PR TITLE
Small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 default: test
 
 test: env
-	.env/bin/py.test -x tests
+	.env/bin/pytest -x tests
 
 env: .env/.up-to-date
 
 
-.env/.up-to-date: setup.py Makefile test_requirements.txt
+.env/.up-to-date: setup.py Makefile setup.cfg
 	virtualenv --no-site-packages .env
-	.env/bin/pip install -e .
+	.env/bin/pip install -e '.[testig]'
 	.env/bin/pip install -r ./*.egg-info/requires.txt || true
-	.env/bin/pip install -r test_requirements.txt
 	touch $@
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![Build Status](https://secure.travis-ci.org/vmalloc/dessert.png)
+![Build Status](https://github.com/vmalloc/dessert/actions/workflows/test.yml/badge.svg?branch=develop)
 ![Version](https://img.shields.io/pypi/v/dessert.svg)
 
 Overview

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,6 @@ from setuptools import setup
 setup(
     setup_requires=['pbr>=3.0', 'setuptools>=17.1'],
     pbr=True,
-    python_requires=">=3.5.*",
+    python_requires=">=3.5",
     long_description_content_type='text/markdown; charset=UTF-8',
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,0 @@
-pytest
-emport>=1.1.1

--- a/tests/test_dessert.py
+++ b/tests/test_dessert.py
@@ -47,7 +47,7 @@ def func():
 """)
     with dessert.rewrite_assertions_context():
         with _disable_pytest_rewriting():
-            with pytest.warns(None) as caught:
+            with pytest.warns((UserWarning)) as caught:
                 emport.import_file(full_path)
             [warning] = caught.list
             assert warning.filename == full_path


### PR DESCRIPTION
* Fix python_requires according to `setuptools` 67.1.0's requirements (fixes #16)
* Fix README's build status link
* Remove `test_requirements.txt` (use testing extra dependency instead)
* Remove usage of deprecated `pytest` API from `unittest`