### PR TITLE
Fix error 'AST node line range is not valid' on Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 summary = Assertion introspection via AST rewriting
 description-file =
     README.md


### PR DESCRIPTION
When running the code on Python 3.11, I came across this error: `ValueError: AST node line range (x, y) is not valid`.

The issue was in the "warn_about_none_ast" function. While generating the final Abstract Syntax Tree (AST) using `ast.parse`, it created incorrect nodes:

```python
ImportFrom(
    lineno=4,
    col_offset=4,
    end_lineno=1,  # end_lineno < lineno
    end_col_offset=61,
    module='dessert.warning_types',
    names=[alias(lineno=4, col_offset=4, end_lineno=1, end_col_offset=61,
                 name='DessertAssertRewriteWarning', asname=None)],
    level=0,
),
ImportFrom(
    lineno=4,
    col_offset=4,
    end_lineno=2,  # end_lineno < lineno
    end_col_offset=34,
    module='warnings',
    names=[alias(lineno=4, col_offset=4, end_lineno=2, end_col_offset=34, 
                 ame='warn_explicit', asname=None)],
    level=0,
)
```

I resolved the problem by replacing `ast.parse` with code generated through `ast.stmt` nodes. I have tested the solution on Python 3.9, 3.10, 3.11, and 3.12-rc.