### PR TITLE
Remove `atomicwrites` dependency

### DIFF
--- a/dessert/rewrite.py
+++ b/dessert/rewrite.py
@@ -21,8 +21,6 @@ from typing import Optional
 from typing import Set
 from typing import Tuple
 
-import atomicwrites
-
 from . import util
 from .util import format_explanation as _format_explanation
 
@@ -231,15 +229,19 @@ def _write_pyc(state, co, source_stat, pyc):
     # (C)Python, since these "pycs" should never be seen by builtin
     # import. However, there's little reason deviate.
     try:
-        with atomicwrites.atomic_write(pyc, mode="wb", overwrite=True, dir=tempfile.gettempdir()) as fp:
-            fp.write(importlib.util.MAGIC_NUMBER)
-            # as of now, bytecode header expects 32-bit numbers for size and mtime (#4903)
-            mtime = int(source_stat.st_mtime) & 0xFFFFFFFF
-            size = source_stat.st_size & 0xFFFFFFFF
-            # "<LL" stands for 2 unsigned longs, little-ending
-            fp.write(struct.pack("<LL", mtime, size))
-            fp.write(marshal.dumps(co))
-    except EnvironmentError as e:
+        with tempfile.TemporaryDirectory(prefix="dessert-pyc-") as tmp_dir:
+            tmp_file = os.path.join(tmp_dir, os.path.basename(pyc))
+            with open(tmp_file, mode="wb") as fp:
+                fp.write(importlib.util.MAGIC_NUMBER)
+                # as of now, bytecode header expects 32-bit numbers for size and mtime (#4903)
+                mtime = int(source_stat.st_mtime) & 0xFFFFFFFF
+                size = source_stat.st_size & 0xFFFFFFFF
+                # "<LL" stands for 2 unsigned longs, little-ending
+                fp.write(struct.pack("<LL", mtime, size))
+                fp.write(marshal.dumps(co))
+
+            os.replace(tmp_file, pyc)
+    except EnvironmentError | OSError as e:
         _logger.debug("error writing pyc file at {}: errno={}".format(pyc, e.errno))
         # we ignore any failure to write the cache file
         # there are many reasons, permission-denied, __pycache__ being a

--- a/dessert/rewrite.py
+++ b/dessert/rewrite.py
@@ -241,7 +241,7 @@ def _write_pyc(state, co, source_stat, pyc):
                 fp.write(marshal.dumps(co))
 
             os.replace(tmp_file, pyc)
-    except EnvironmentError | OSError as e:
+    except (EnvironmentError, OSError) as e:
         _logger.debug("error writing pyc file at {}: errno={}".format(pyc, e.errno))
         # we ignore any failure to write the cache file
         # there are many reasons, permission-denied, __pycache__ being a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 
-dependencies = ["munch", "py", "atomicwrites>=1.0", "attrs"]
+dependencies = ["munch", "py", "attrs"]
 
 dynamic = ["version"]
 


### PR DESCRIPTION
`atomicwrites` is archived and does not have any wheels published for it. 
https://github.com/untitaker/python-atomicwrites/blob/4183999d9b7e81af85dee070d5311299bdf5164c/README.rst?plain=1#L5-L12

This change avoids this issue by replacing the need for the dependency as it's use was already limited.